### PR TITLE
Hide tags starting with underscore from user display

### DIFF
--- a/automad/src/server/Engine/Processors/Features/ForEachLoopProcessor.php
+++ b/automad/src/server/Engine/Processors/Features/ForEachLoopProcessor.php
@@ -121,6 +121,10 @@ class ForEachLoopProcessor extends AbstractFeatureProcessor {
 			// Each filter can be used as @{:filter} within a snippet.
 
 			foreach ($this->Automad->Pagelist->getTags() as $filter) {
+				// Skip tags starting with underscore
+				if (strpos($filter, '_') === 0) {
+					continue;
+				}
 				Debug::log($filter, 'Processing snippet in loop for filter');
 				// Store current filter in the system variable buffer.
 				$this->Automad->Runtime->set(Fields::FILTER, $filter);
@@ -132,6 +136,10 @@ class ForEachLoopProcessor extends AbstractFeatureProcessor {
 			// Tags (of the current page)
 			// Each tag can be used as @{:tag} within a snippet.
 			foreach ($Context->get()->tags as $tag) {
+				// Skip tags starting with underscore
+				if (strpos($tag, '_') === 0) {
+					continue;
+				}
 				Debug::log($tag, 'Processing snippet in loop for tag');
 				// Store current tag in the system variable buffer.
 				$this->Automad->Runtime->set(Fields::TAG, $tag);


### PR DESCRIPTION
## Overview
Add functionality to hide tags that start with an underscore (`_`) from user-facing displays, while still allowing them to be used internally for filtering purposes.

## Problem
Tags are useful for filtering content, but there's no way to use a tag purely for organizational/filtering purposes without displaying it to users.

## Solution
Tags starting with an underscore are now hidden from user-facing tag lists and displays, but remain available for internal filtering operations.

## Changes
- Tags beginning with `_` are excluded from public tag displays
- Filtering by underscore-prefixed tags continues to work normally
- No breaking changes to existing tag functionality