### PR TITLE
Add JSON_UNESCAPED_UNICODE to store UTF-8 characters

### DIFF
--- a/automad/src/server/Core/FileSystem.php
+++ b/automad/src/server/Core/FileSystem.php
@@ -645,6 +645,6 @@ class FileSystem {
 	 * @return bool
 	 */
 	public static function writeJson(string $file, array $data): bool {
-		return self::write($file, strval(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)));
+		return self::write($file, strval(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)));
 	}
 }


### PR DESCRIPTION
## Description:

This PR adds the JSON_UNESCAPED_UNICODE flag to the JSON encoding used when writing content files.
Currently Automad stores Unicode characters (e.g. á, é, ő, ű) as escaped sequences such as \u00e1.
This makes direct editing of content files on UTF‑8 systems (Linux, editors, Git workflows) less convenient.

## What this PR changes
In Core/FileSystem.php, the JSON encoding used for writing data files is updated:

`json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
`
This ensures that content files are saved with readable UTF‑8 characters instead of escaped Unicode sequences.

## Why this is beneficial
- Content files become human‑readable UTF‑8 text.
- Editing content directly on the server or in Git becomes much easier.
- JSON remains fully valid and standards‑compliant.
- PHP automatically handles both escaped and unescaped Unicode on read, so this change is fully backward‑compatible.

## Backward compatibility
No migration is required:

- Existing files with escaped Unicode continue to load correctly.
- New saves will produce UTF‑8 characters.
- Mixed files (escaped + unescaped) work without issues.

## Related issue
Fixes #184